### PR TITLE
DB scripts

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -14,31 +14,42 @@ var mongoose = require('mongoose');
  */
 
 // new port step 1
-var port = process.env.PORT || '3000';
+var port = process.env.PORT || '3000'; // uses the first otherwise defaults to PORT 3000
 app.set('port', port);
 
 /*
 Setup MongoDB connection
 */
+console.log("Which DB are we connecting to?", process.env.MONGODB_URL);
 
-var environment = "testing";
-
-if ( environment === "local" ) {
-  mongoose.connect('mongodb://localhost/re_engage', {
-        useNewUrlParser: true,
-        useUnifiedTopology: true
-      });
-} else if ( environment === "testing" ) {
-  mongoose.connect('mongodb://localhost/re_engage_test', {
-        useNewUrlParser: true,
-        useUnifiedTopology: true
-      });
-} else { // live environment
-  mongoose.connect(process.env.MONGOLAB_URI, {
+mongoose.connect(process.env.MONGODB_URL, {
     useNewUrlParser: true,
     useUnifiedTopology: true, 
-  });
-}
+  }
+);
+
+mongoose.connection.on('connected', () => {
+  console.log('Mongoose is connected!');
+});
+
+// var environment = "development";
+
+// if ( environment === "development" ) {
+//   mongoose.connect('mongodb://localhost/re_engage', {
+//         useNewUrlParser: true,
+//         useUnifiedTopology: true
+//       });
+// } else if ( environment === "testing" ) {
+//   mongoose.connect('mongodb://localhost/re_engage_test', {
+//         useNewUrlParser: true,
+//         useUnifiedTopology: true
+//       });
+// } else { // production environment
+//   mongoose.connect(process.env.MONGOLAB_URI, {
+//     useNewUrlParser: true,
+//     useUnifiedTopology: true, 
+//   });
+// }
 
 // if ( process.env.MONGOLAB_URI ) {
 //   mongoose.connect(process.env.MONGOLAB_URI, {
@@ -53,9 +64,9 @@ if ( environment === "local" ) {
 //   });
 // }
 
-mongoose.connection.on('connected', () => {
-  console.log('Mongoose is connected!');
-});
+// mongoose.connection.on('connected', () => {
+//   console.log('Mongoose is connected!');
+// });
 
 /**
  * Create HTTP server.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "private": true,
   "scripts": {
     "start": "nodemon ./bin/www",
+    "start:dev": "PORT=3000 MONGODB_URL='mongodb://localhost/re_engage' npm start ",
+    "start:test": "PORT=3030 MONGODB_URL='mongodb://localhost/re_engage_test' npm start ",
+    "start:prod": "PORT=3000 MONGOLAB_URI npm start",
+    "test": "npm run test:unit && npm run test:integration",
     "test:unit": "jest",
-    "test:integration": "cypress run",
-    "test": "npm run test:unit && npm run test:integration"
+    "test:integration": "cypress run"
+    
   },
   "dependencies": {
     "@google/maps": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "nodemon ./bin/www",
     "start:dev": "PORT=3000 MONGODB_URL='mongodb://localhost/re_engage' npm start ",
     "start:test": "PORT=3030 MONGODB_URL='mongodb://localhost/re_engage_test' npm start ",
-    "start:prod": "PORT=3000 MONGOLAB_URI npm start",
+    "start:prod": "npm start",
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "jest",
     "test:integration": "cypress run"


### PR DESCRIPTION
This merge will:
- Update `package.json` and `www` files so that different app environments will connect to the right DB
- Scripts include: 
  - "start": "nodemon ./bin/www",
  - "start:dev": "PORT=3000 MONGODB_URL='mongodb://localhost/re_engage' npm start ",
  - "start:test": "PORT=3030 MONGODB_URL='mongodb://localhost/re_engage_test' npm start ",
  - "start:prod": "npm start",
- `www` file changes the connection instructions:
  - ```mongoose.connect(process.env.MONGODB_URL, {```
        ```useNewUrlParser: true,```
        ``` useUnifiedTopology: true, ```
          ```}```
```);```
- `.ENV` file must be modified so that you replace `MONGOLAB_URI` with `MONGODB_URL`